### PR TITLE
fix(VisibleRows): properly sync `rows` prop with the table state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pricemoov-oss/react-table",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "React components for efficiently rendering large tabular data",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/table/elementary-table.tsx
+++ b/src/components/table/elementary-table.tsx
@@ -21,9 +21,7 @@ export interface ITree {
   subTrees?: ITrees;
 }
 
-export interface ITrees {
-  [rowIndex: number]: ITree;
-}
+export type ITrees = Record<number, ITree>;
 
 export interface IColumnOptions {
   className?: string;

--- a/stories/components/table/virtualized-table.stories.tsx
+++ b/stories/components/table/virtualized-table.stories.tsx
@@ -10,6 +10,7 @@ import { withThemeProvider } from "../../utils/decorators";
 import { generateTable, generateTableWithCustomColspan, generateRow } from "../../utils/tables";
 import { TableColumnsRowsController, TableScrollController } from "../../stories-components/selection-menu";
 import { GroupCellProps } from "../../../src/components/table/group-rows";
+import { TableWithDynamicSubColumns } from "../../stories-components/dynamic-sub-columns";
 
 const storyInfoDefault = {
   inline: true,
@@ -231,6 +232,13 @@ storiesOf("Table/Virtualized", module)
         />
       </div>
     ),
+    { notes: { markdown: Readme } }
+  )
+  .add(
+    "With dynamic sub rows",
+    () => {
+      return <TableWithDynamicSubColumns />;
+    },
     { notes: { markdown: Readme } }
   )
   .add(

--- a/stories/stories-components/dynamic-sub-columns.tsx
+++ b/stories/stories-components/dynamic-sub-columns.tsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+import { IRow } from "../../src";
+import Table from "../../src/components/table/table";
+import { boolean } from "@storybook/addon-knobs";
+import { generateRow, generateTable } from "../utils/tables";
+import { Button } from "@mui/material";
+
+function generateTableWithSubRowSize(size: number) {
+  const table = generateTable(size, 100, {}, true);
+  const lastRow: IRow = table.rows[size - 1];
+  lastRow.cells[0].subItems = [generateRow(1, 100, false, 2, undefined, size), generateRow(2, 100, false, 2, undefined, size)];
+  return table;
+}
+
+export const TableWithDynamicSubColumns = () => {
+  const [table, setTable] = React.useState(() => generateTableWithSubRowSize(200));
+
+  const to100RowsSize = () => {
+    setTable(generateTableWithSubRowSize(100));
+  };
+
+  const to200Rows = () => {
+    setTable(generateTableWithSubRowSize(200));
+  };
+
+  return (
+    <React.Fragment>
+      <Button color="primary" disabled={table.rows.length === 100} onClick={to100RowsSize}>
+        Switch to 100 subrows
+      </Button>
+      <Button color="primary" disabled={table.rows.length === 200} onClick={to200Rows}>
+        Switch to 200 subrows
+      </Button>
+      <div style={{ height: "90vh", width: "100%" }}>
+        <Table
+          id="table-foo"
+          rows={table.rows}
+          globalColumnProps={{ style: { justifyContent: "left" } }}
+          columns={{ 0: { size: 180 } }}
+          isVirtualized
+          isSpan={boolean("isSpan", false)}
+          virtualizerProps={{
+            rowsCount: 10,
+            columnsCount: 10,
+          }}
+        />
+      </div>
+    </React.Fragment>
+  );
+};

--- a/stories/utils/tables.ts
+++ b/stories/utils/tables.ts
@@ -176,6 +176,43 @@ export const subMiam: IRow[] = [
   },
 ];
 
+export const subMiamMiam: IRow[] = [
+  {
+    id: "miam",
+    cells: [
+      {
+        id: "sushi",
+        value: "Sushi",
+      },
+      {
+        id: "pizza",
+        value: "Pizza",
+      },
+      {
+        id: "mafe",
+        value: "Mafe",
+      },
+    ],
+  },
+  {
+    id: "miam-miam",
+    cells: [
+      {
+        id: "carrot",
+        value: "Carrot",
+      },
+      {
+        id: "apple",
+        value: "Apple",
+      },
+      {
+        id: "pear",
+        value: "Pear",
+      },
+    ],
+  },
+];
+
 export const tableWithSubItems = ({
   firstSubRows = [],
   secondSubRows = [],
@@ -507,7 +544,14 @@ function generateRowWithCustomColumns(
   });
 }
 
-export function generateRow(index: number, cellsCount: number, subRow = false, level = 0, colspanMatrix?: any): IRow {
+export function generateRow(
+  index: number,
+  cellsCount: number,
+  subRow = false,
+  level = 0,
+  colspanMatrix?: any,
+  subSize = 20
+): IRow {
   const cells = Array.from(Array(cellsCount), (_, cellIndex) => {
     const currentCell =
       colspanMatrix && colspanMatrix[index]
@@ -519,7 +563,9 @@ export function generateRow(index: number, cellsCount: number, subRow = false, l
       colspan: currentCell ? currentCell.colspan : 1,
       subItems:
         subRow && cellIndex === 0 && index === 2
-          ? Array.from(Array(20), (_, rowIndex) => generateRow(rowIndex, cellsCount, level <= 2, level + 1))
+          ? Array.from(Array(subSize), (_, rowIndex) =>
+              generateRow(rowIndex, cellsCount, level <= 2, level + 1, colspanMatrix, subSize)
+            )
           : [],
     };
   });
@@ -531,7 +577,9 @@ export function generateRow(index: number, cellsCount: number, subRow = false, l
 }
 
 export function generateTable(rowsCount: number, cellsCount: number, props = {}, subRow = false) {
-  const rows = Array.from(Array(rowsCount), (_, rowIndex) => generateRow(rowIndex, cellsCount, subRow));
+  const rows = Array.from(Array(rowsCount), (_, rowIndex) =>
+    generateRow(rowIndex, cellsCount, subRow, undefined, undefined, rowsCount)
+  );
   return {
     id: "table-foo",
     ...props,

--- a/test/components/table/table.test.tsx
+++ b/test/components/table/table.test.tsx
@@ -3,7 +3,7 @@ import { createRenderer } from "react-test-renderer/shallow";
 
 import { mount } from "enzyme";
 import Table, { IState } from "../../../src/components/table/table";
-import { simpleTable, tableWithSubItems, subRows, subMiam, generateTable } from "../../../stories/utils/tables";
+import { simpleTable, tableWithSubItems, subRows, subMiam, generateTable, subMiamMiam } from "../../../stories/utils/tables";
 import { withThemeProvider } from "../../../stories/utils/decorators";
 import { getIndexesIdsMapping } from "../../../src/components/utils/table";
 
@@ -153,6 +153,33 @@ describe("Table component", () => {
       rowsLength: 4,
       fixedRowsIndexes: [],
     };
+    expect(instance.state).toEqual(expectedState);
+  });
+
+  test("should render sub rows even if the sub row size has changed", () => {
+    const props = {
+      id: "foo",
+      rows: subRows({ subsubRows: subMiamMiam }),
+    };
+    const wrapper = mount(withThemeProvider(() => <Table {...props} />));
+    wrapper.setProps({ rows: subRows({ subsubRows: subMiam }) });
+
+    const instance: Table = wrapper.find(Table).instance() as Table;
+    // @ts-ignore private method
+    const expectedState: IState = {
+      rowsLength: 2,
+      indexesMapping: {
+        absolute: {
+          "0": { index: 0, parentIndex: null },
+          "1": { index: 1, parentIndex: null },
+        },
+        relative: { "0": { index: 0 }, "1": { index: 1 } },
+      },
+      columnsIndexesIdsMapping: getIndexesIdsMapping(props.rows[0].cells),
+      openedTrees: {},
+      fixedRowsIndexes: [],
+    };
+
     expect(instance.state).toEqual(expectedState);
   });
 


### PR DESCRIPTION
### Your checklist for this pull request

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **master branch** (left side). Also you should start _your branch_ off _our master_.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will pass linting.

### Description

This fixes a crash happening when the `subItems` count gets smaller after a state update.
When this happens, `visibleRowIndices` remains the same length (because it is coming from a cache in the virtualizer), so the `visibleRowIndices`' length is bigger than the available rows' length on next render. Which results in `undefine`s which crashes the app.

I've added a story `table-virtualized--with-dynamic-sub-rows` that reproduces the issue:

Story with the bug:

[screen-capture (3).webm](https://github.com/PricemoovOSS/react-table/assets/13306328/839b17b3-a317-4635-a904-d0c7f8f56077)

Story without the bug:

[screen-capture (4).webm](https://github.com/PricemoovOSS/react-table/assets/13306328/3a224856-51f6-4ae6-bdc4-80e382f423f9)


💔 Thank you!
